### PR TITLE
Protect path with double quote

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,7 @@ export async function activate(context: vscode.ExtensionContext) {
 				return;
 			}
 			try {
-				const shellExec = new vscode.ShellExecution(`npx playwright show-trace ${path} `);
+				const shellExec = new vscode.ShellExecution(`npx playwright show-trace "${path}" `);
 				let tsk = new vscode.Task({ type: `trace-viewer${Math.random()}` },
 					vscode.TaskScope.Workspace,
 					'trace-viewer',


### PR DESCRIPTION
fix #1 on windows 10